### PR TITLE
feat: presigned url api 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,7 @@ jobs:
 
             docker run -d -p 3000:3000 \
               --name ${{ env.CONTAINER_NAME }} \
+              --network tmc-network \
               --env-file /home/${{ secrets.REMOTE_USERNAME_DEV }}/.env \
               --restart=unless-stopped \
               --log-opt max-size=10m --log-opt max-file=3 \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
 
   CD:
     needs: [CI]
-    if: github.event_name == 'push'  # push 이벤트에서만 CD 실행
+    if: github.event_name == 'push'
     runs-on: ubuntu-20.04
     steps:
       - name: Deploy to Server
@@ -70,6 +70,7 @@ jobs:
           port: ${{ secrets.REMOTE_PORT_DEV }}
           script: |
             docker login -u ${{ secrets.DOCKER_ID }} -p ${{ secrets.DOCKER_PASSWORD }}
+
             docker stop ${{ env.CONTAINER_NAME }} || true
             docker rm ${{ env.CONTAINER_NAME }} || true
             docker image rm ${{ secrets.DOCKER_ID }}/${{ env.CONTAINER_NAME }} || true
@@ -82,6 +83,17 @@ jobs:
               --env-file /home/${{ secrets.REMOTE_USERNAME_DEV }}/.env \
               --restart=unless-stopped \
               --log-opt max-size=10m --log-opt max-file=3 \
-              ${{ secrets.DOCKER_ID }}/${{ env.CONTAINER_NAME }}:${{ github.run_number }}
+              ${{ secrets.DOCKER_ID }}/${{ env.CONTAINER_NAME }}:${{ github.run_number }} || {
+                echo "Deployment failed, rolling back to latest image..."
+                docker run -d -p 3000:3000 \
+                  --name ${{ env.CONTAINER_NAME }} \
+                  --network tmc-network \
+                  --env-file /home/${{ secrets.REMOTE_USERNAME_DEV }}/.env \
+                  --restart=unless-stopped \
+                  --log-opt max-size=10m --log-opt max-file=3 \
+                  ${{ secrets.DOCKER_ID }}/${{ env.CONTAINER_NAME }}:latest
+                exit 1
+              }
 
+            # 사용하지 않는 이미지 정리
             docker image prune -f

--- a/package.json
+++ b/package.json
@@ -33,13 +33,16 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "dotenv": "^16.4.5",
+    "minio": "^8.0.4",
     "mysql2": "^3.12.0",
+    "nestjs-minio": "^2.6.2",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.12.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
-    "typeorm": "^0.3.20"
+    "typeorm": "^0.3.20",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,9 +47,15 @@ importers:
       dotenv:
         specifier: ^16.4.5
         version: 16.4.7
+      minio:
+        specifier: ^8.0.4
+        version: 8.0.4
       mysql2:
         specifier: ^3.12.0
         version: 3.12.0
+      nestjs-minio:
+        specifier: ^2.6.2
+        version: 2.6.2(@nestjs/common@10.4.15(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.15)
       passport:
         specifier: ^0.7.0
         version: 0.7.0
@@ -68,6 +74,9 @@ importers:
       typeorm:
         specifier: ^0.3.20
         version: 0.3.21(mysql2@3.12.0)(pg@8.13.3)(reflect-metadata@0.2.2)(ts-node@10.9.2(@types/node@20.17.23)(typescript@5.8.2))
+      uuid:
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@nestjs/cli':
         specifier: ^10.0.0
@@ -868,6 +877,9 @@ packages:
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
+  '@zxing/text-encoding@0.9.0':
+    resolution: {integrity: sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -1038,6 +1050,9 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  block-stream2@2.1.0:
+    resolution: {integrity: sha512-suhjmLI57Ewpmq00qaygS8UgEq2ly2PCItenIyhMqVjo4t4pGzqMvfgJuX8iWTeSDdfSSqS6j38fL4ToNL7Pfg==}
+
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -1052,6 +1067,9 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  browser-or-node@2.1.1:
+    resolution: {integrity: sha512-8CVjaLJGuSKMVTxJ2DpBl5XnlNDiT4cQFeuCJJrvJmts9YrTZDizTX7PjC2s6W4x+MBGZeEY6dGMrF04/6Hgqg==}
+
   browserslist@4.24.4:
     resolution: {integrity: sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -1063,6 +1081,10 @@ packages:
 
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
+
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -1288,6 +1310,10 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decode-uri-component@0.2.2:
+    resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
+    engines: {node: '>=0.10'}
 
   dedent@1.5.3:
     resolution: {integrity: sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==}
@@ -1517,6 +1543,9 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
   events@1.1.1:
     resolution: {integrity: sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==}
     engines: {node: '>=0.4.x'}
@@ -1567,6 +1596,10 @@ packages:
   fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
 
+  fast-xml-parser@4.5.3:
+    resolution: {integrity: sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==}
+    hasBin: true
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -1587,6 +1620,10 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  filter-obj@1.1.0:
+    resolution: {integrity: sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==}
+    engines: {node: '>=0.10.0'}
 
   finalhandler@1.3.1:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
@@ -1810,6 +1847,10 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  ipaddr.js@2.2.0:
+    resolution: {integrity: sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==}
+    engines: {node: '>= 10'}
 
   is-arguments@1.2.0:
     resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
@@ -2283,6 +2324,10 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minio@8.0.4:
+    resolution: {integrity: sha512-GVW7y2PNbzjjFJ9opVMGKvDNuRkyz3bMt1q7UrHs7bsKFWLXbSvMPffjE/HkVYWUjlD8kQwMaeqiHhhvZJJOfQ==}
+    engines: {node: ^16 || ^18 || >=20}
+
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -2325,6 +2370,12 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  nestjs-minio@2.6.2:
+    resolution: {integrity: sha512-RRrOyt0mZi6VOgm0KZSkeYRnFWMr1z+aaKzmnB/eOwBT11XGjqeY9aNEkPCMjBe+PFd6rethMV+bLtO9YXMsSA==}
+    peerDependencies:
+      '@nestjs/common': '>7.0.0'
+      '@nestjs/core': '>7.0.0'
 
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
@@ -2587,6 +2638,10 @@ packages:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
 
+  query-string@7.1.3:
+    resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
+    engines: {node: '>=6'}
+
   querystring@0.2.0:
     resolution: {integrity: sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==}
     engines: {node: '>=0.4.x'}
@@ -2796,6 +2851,10 @@ packages:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
 
+  split-on-first@1.1.0:
+    resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
+    engines: {node: '>=6'}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
@@ -2819,9 +2878,19 @@ packages:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
 
+  stream-chain@2.2.5:
+    resolution: {integrity: sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==}
+
+  stream-json@1.9.1:
+    resolution: {integrity: sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==}
+
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
+
+  strict-uri-encode@2.0.0:
+    resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
+    engines: {node: '>=4'}
 
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
@@ -2864,6 +2933,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strnum@1.1.2:
+    resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
 
   superagent@8.1.2:
     resolution: {integrity: sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==}
@@ -2928,6 +3000,9 @@ packages:
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  through2@4.0.2:
+    resolution: {integrity: sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -3181,6 +3256,9 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-encoding@1.1.5:
+    resolution: {integrity: sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -4256,6 +4334,9 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
+  '@zxing/text-encoding@0.9.0':
+    optional: true
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -4446,6 +4527,10 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  block-stream2@2.1.0:
+    dependencies:
+      readable-stream: 3.6.2
+
   body-parser@1.20.3:
     dependencies:
       bytes: 3.1.2
@@ -4476,6 +4561,8 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  browser-or-node@2.1.1: {}
+
   browserslist@4.24.4:
     dependencies:
       caniuse-lite: 1.0.30001701
@@ -4490,6 +4577,8 @@ snapshots:
   bser@2.1.1:
     dependencies:
       node-int64: 0.4.0
+
+  buffer-crc32@1.0.0: {}
 
   buffer-equal-constant-time@1.0.1: {}
 
@@ -4705,6 +4794,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decode-uri-component@0.2.2: {}
+
   dedent@1.5.3: {}
 
   deep-is@0.1.4: {}
@@ -4913,6 +5004,8 @@ snapshots:
 
   etag@1.8.1: {}
 
+  eventemitter3@5.0.1: {}
+
   events@1.1.1: {}
 
   events@3.3.0: {}
@@ -5001,6 +5094,10 @@ snapshots:
 
   fast-uri@3.0.6: {}
 
+  fast-xml-parser@4.5.3:
+    dependencies:
+      strnum: 1.1.2
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -5024,6 +5121,8 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  filter-obj@1.1.0: {}
 
   finalhandler@1.3.1:
     dependencies:
@@ -5295,6 +5394,8 @@ snapshots:
       wrap-ansi: 6.2.0
 
   ipaddr.js@1.9.1: {}
+
+  ipaddr.js@2.2.0: {}
 
   is-arguments@1.2.0:
     dependencies:
@@ -5918,6 +6019,23 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minio@8.0.4:
+    dependencies:
+      async: 3.2.6
+      block-stream2: 2.1.0
+      browser-or-node: 2.1.1
+      buffer-crc32: 1.0.0
+      eventemitter3: 5.0.1
+      fast-xml-parser: 4.5.3
+      ipaddr.js: 2.2.0
+      lodash: 4.17.21
+      mime-types: 2.1.35
+      query-string: 7.1.3
+      stream-json: 1.9.1
+      through2: 4.0.2
+      web-encoding: 1.1.5
+      xml2js: 0.6.2
+
   minipass@7.1.2: {}
 
   mkdirp@0.5.6:
@@ -5963,6 +6081,12 @@ snapshots:
   negotiator@0.6.3: {}
 
   neo-async@2.6.2: {}
+
+  nestjs-minio@2.6.2(@nestjs/common@10.4.15(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.15):
+    dependencies:
+      '@nestjs/common': 10.4.15(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.15(@nestjs/common@10.4.15(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.15)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      minio: 8.0.4
 
   node-abort-controller@3.1.1: {}
 
@@ -6191,6 +6315,13 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  query-string@7.1.3:
+    dependencies:
+      decode-uri-component: 0.2.2
+      filter-obj: 1.1.0
+      split-on-first: 1.1.0
+      strict-uri-encode: 2.0.0
+
   querystring@0.2.0: {}
 
   queue-microtask@1.2.3: {}
@@ -6417,6 +6548,8 @@ snapshots:
 
   source-map@0.7.4: {}
 
+  split-on-first@1.1.0: {}
+
   split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
@@ -6431,7 +6564,15 @@ snapshots:
 
   statuses@2.0.1: {}
 
+  stream-chain@2.2.5: {}
+
+  stream-json@1.9.1:
+    dependencies:
+      stream-chain: 2.2.5
+
   streamsearch@1.1.0: {}
+
+  strict-uri-encode@2.0.0: {}
 
   string-length@4.0.2:
     dependencies:
@@ -6473,6 +6614,8 @@ snapshots:
   strip-final-newline@2.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  strnum@1.1.2: {}
 
   superagent@8.1.2:
     dependencies:
@@ -6540,6 +6683,10 @@ snapshots:
       minimatch: 3.1.2
 
   text-table@0.2.0: {}
+
+  through2@4.0.2:
+    dependencies:
+      readable-stream: 3.6.2
 
   through@2.3.8: {}
 
@@ -6736,6 +6883,12 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  web-encoding@1.1.5:
+    dependencies:
+      util: 0.12.5
+    optionalDependencies:
+      '@zxing/text-encoding': 0.9.0
 
   webidl-conversions@3.0.1: {}
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,10 +4,16 @@ import { UsersModule } from './domain/users/module/users.module';
 import * as dotenv from 'dotenv';
 import { DatabaseModule } from './global/database/module/database.module';
 import { AuthModule } from './global/auth/module/auth.module';
+import { MinioModule } from './domain/s3/module/minio.module';
 
 dotenv.config();
 @Module({
-  imports: [DatabaseModule, UsersModule, AuthModule],
+  imports: [
+    DatabaseModule,
+    UsersModule,
+    AuthModule,
+    MinioModule,
+  ],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {

--- a/src/domain/s3/controller/minio.controller.ts
+++ b/src/domain/s3/controller/minio.controller.ts
@@ -1,0 +1,48 @@
+import {
+  Controller,
+  Get,
+  Param,
+  UseFilters,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { MinioService } from '../service/minio.service';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../../global/common/guards/jwt-auth.guard';
+import { ResponseInterceptor } from '../../../global/common/interceptor/response.interceptor';
+import { HttpExceptionFilter } from '../../../global/exception/filter/http-exception.filter';
+import { ResponseDto } from '../../../global/exception/dto/response.dto';
+
+@ApiTags('S3 파일 업로드/다운로드')
+@Controller('api/v1/s3')
+@UseInterceptors(ResponseInterceptor)
+@UseFilters(HttpExceptionFilter)
+export class MinioController {
+  constructor(private readonly minioService: MinioService) {}
+
+  @ApiOperation({ summary: 'S3 Presigned URL (업로드)' })
+  @ApiBearerAuth()
+  @ApiResponse({ status: 200, description: 'Presigned URL 반환 성공' })
+  @Get('upload/:fileName')
+  @UseGuards(JwtAuthGuard)
+  async getUploadUrl(): Promise<ResponseDto<any>> {
+    const url = await this.minioService.getPresignedUrlForUpload();
+
+    return ResponseDto.ok(url);
+  }
+
+  @ApiOperation({ summary: 'S3 Presigned URL (다운로드)' })
+  @Get('download/:fileName')
+  async getDownloadUrl(
+    @Param('fileName') fileName: string,
+  ): Promise<ResponseDto<any>> {
+    const url = await this.minioService.getPresignedUrlForDownload(fileName);
+
+    return ResponseDto.ok(url);
+  }
+}

--- a/src/domain/s3/dto/presigned-url.dto.ts
+++ b/src/domain/s3/dto/presigned-url.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PresignedUrlDto {
+  @ApiProperty({
+    example: 'http://localhost:9000/nestjs-bucket/1596445630123-myfile.jpg?...',
+    description: 'Presigned URL입니다.',
+  })
+  url: string;
+
+  static of(url: string): PresignedUrlDto {
+    const dto = new PresignedUrlDto();
+    dto.url = url;
+    return dto;
+  }
+}

--- a/src/domain/s3/module/minio.module.ts
+++ b/src/domain/s3/module/minio.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { MinioService } from '../service/minio.service';
+import { MinioController } from '../controller/minio.controller';
+
+@Module({
+  controllers: [MinioController],
+  providers: [MinioService],
+  exports: [MinioService],
+})
+export class MinioModule {}

--- a/src/domain/s3/service/minio.service.ts
+++ b/src/domain/s3/service/minio.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import * as dotenv from 'dotenv';
 import { v4 as uuidv4 } from 'uuid';
 import { Client } from 'minio';
@@ -59,11 +59,11 @@ export class MinioService {
     try {
       const exists = await this.minioClient.bucketExists(this.bucket);
       if (!exists) {
-        console.log(`버킷 '${this.bucket}'이 존재하지 않음. 생성 중...`);
+        Logger.log(`버킷 '${this.bucket}'이 존재하지 않음. 생성 중...`);
         await this.minioClient.makeBucket(this.bucket);
-        console.log(`버킷 '${this.bucket}' 생성 완료.`);
+        Logger.log(`버킷 '${this.bucket}' 생성 완료.`);
       } else {
-        console.log(`버킷 '${this.bucket}'이 이미 존재합니다.`);
+        Logger.error(`버킷 '${this.bucket}'이 이미 존재합니다.`);
       }
     } catch (error) {
       console.error(`버킷 확인 중 오류 발생:`, error);

--- a/src/domain/s3/service/minio.service.ts
+++ b/src/domain/s3/service/minio.service.ts
@@ -1,0 +1,78 @@
+import { Injectable } from '@nestjs/common';
+import * as dotenv from 'dotenv';
+import { v4 as uuidv4 } from 'uuid';
+import { Client } from 'minio';
+import { CommonException } from '../../../global/exception/common-exception';
+import { ErrorCode } from '../../../global/exception/error-code';
+import { ResponseDto } from '../../../global/exception/dto/response.dto';
+import { PresignedUrlDto } from '../dto/presigned-url.dto';
+
+dotenv.config();
+
+@Injectable()
+export class MinioService {
+  private readonly minioClient: Client;
+  private readonly bucket: string = process.env.MINIO_BUCKET_NAME!;
+  private readonly expiration: number = 60;
+
+  constructor() {
+    this.minioClient = new Client({
+      endPoint: process.env.MINIO_ENDPOINT!,
+      port: Number(process.env.MINIO_PORT),
+      useSSL: process.env.MINIO_USE_SSL === 'true',
+      accessKey: process.env.MINIO_ACCESS_KEY!,
+      secretKey: process.env.MINIO_SECRET_KEY!,
+    });
+  }
+
+  async onModuleInit() {
+    await this.ensureBucketExists();
+  }
+
+  async getPresignedUrlForUpload(): Promise<PresignedUrlDto> {
+    const fileName = this.generateFileUploadUrl();
+    let url: string;
+
+    try {
+      url = await this.minioClient.presignedPutObject(this.bucket, fileName, this.expiration);
+    } catch (error) {
+      throw new CommonException(ErrorCode.UPLOAD_FILE_ERROR);
+    }
+
+    return PresignedUrlDto.of(url);
+  }
+  async getPresignedUrlForDownload(
+    fileName: string,
+  ): Promise<PresignedUrlDto> {
+    let url: string;
+
+    try {
+      url = await this.minioClient.presignedGetObject(this.bucket, fileName, this.expiration * 60 * 24);
+    } catch (error) {
+      throw new CommonException(ErrorCode.DOWNLOAD_FILE_ERROR);
+    }
+
+    return PresignedUrlDto.of(url);
+  }
+
+  private async ensureBucketExists() {
+    try {
+      const exists = await this.minioClient.bucketExists(this.bucket);
+      if (!exists) {
+        console.log(`버킷 '${this.bucket}'이 존재하지 않음. 생성 중...`);
+        await this.minioClient.makeBucket(this.bucket);
+        console.log(`버킷 '${this.bucket}' 생성 완료.`);
+      } else {
+        console.log(`버킷 '${this.bucket}'이 이미 존재합니다.`);
+      }
+    } catch (error) {
+      console.error(`버킷 확인 중 오류 발생:`, error);
+    }
+  }
+
+  private generateFileUploadUrl(): string {
+    const timestamp = Date.now();
+    const uuidPart = uuidv4().split('-').join('').substring(0, 5);
+    return `${timestamp}_${uuidPart}`;
+  }
+}

--- a/src/global/exception/error-code.ts
+++ b/src/global/exception/error-code.ts
@@ -36,11 +36,12 @@ export enum ErrorCode {
   TOKEN_TYPE_ERROR = '잘못된 토큰 타입입니다.',
   TOKEN_UNSUPPORTED_ERROR = '지원하지 않는 토큰입니다.',
   TOKEN_GENERATION_ERROR = '토큰 생성에 실패했습니다.',
-  TOKEN_UNKNOW_ERROR = '알 수 없는 토큰입니다.',
+  TOKEN_UNKNOWN_ERROR = '알 수 없는 토큰입니다.',
 
   // Internal Server Error
   INTERNAL_SERVER_ERROR = '서버 내부 오류입니다.',
-  UPLOAD_FILE_ERROR = '파일 업로드에 실패했습니다.',
+  UPLOAD_FILE_ERROR = '파일 업로드 URL 생성에 실패했습니다.',
+  DOWNLOAD_FILE_ERROR = '파일 다운로드 URL 생성에 실패했습니다.',
 }
 
 export function getHttpStatus(errorCode: ErrorCode): HttpStatus {
@@ -95,7 +96,7 @@ export function getHttpStatus(errorCode: ErrorCode): HttpStatus {
       return HttpStatus.UNAUTHORIZED;
     case ErrorCode.TOKEN_GENERATION_ERROR:
       return HttpStatus.UNAUTHORIZED;
-    case ErrorCode.TOKEN_UNKNOW_ERROR:
+    case ErrorCode.TOKEN_UNKNOWN_ERROR:
       return HttpStatus.UNAUTHORIZED;
     case ErrorCode.INTERNAL_SERVER_ERROR:
       return HttpStatus.INTERNAL_SERVER_ERROR;


### PR DESCRIPTION
설계 방법

1. 업로드용 presigned-url 생성 요청
2. generate uuid 값을 통해 미니오에 파일 업로드
3. photos, attachments 등 도메인 생성 후 uuid 값 저장
4. 이후 프론트 요청 시 해당 uuid 값을 fileName으로 요청
5. fileName을 기반으로 다운로드용 presigned-url 생성
6. 프론트에서 해당 url 기반으로 다운로드